### PR TITLE
add a probable fix for observer crash on ios12

### DIFF
--- a/GSPlayer/Classes/View/VideoPlayerView.swift
+++ b/GSPlayer/Classes/View/VideoPlayerView.swift
@@ -160,6 +160,11 @@ open class VideoPlayerView: UIView {
     }
     
     deinit {
+        playerLayerReadyForDisplayObservation?.invalidate()
+        playerTimeControlStatusObservation?.invalidate()
+        playerBufferingObservation?.invalidate()
+        playerItemStatusObservation?.invalidate()
+        playerItemKeepUpObservation?.invalidate()
         NotificationCenter.default.removeObserver(self)
     }
 }

--- a/GSPlayer/Classes/View/VideoPlayerView.swift
+++ b/GSPlayer/Classes/View/VideoPlayerView.swift
@@ -337,6 +337,9 @@ private extension VideoPlayerView {
     func observe(playerItem: AVPlayerItem?) {
         
         guard let playerItem = playerItem else {
+            playerBufferingObservation?.invalidate()
+            playerItemStatusObservation?.invalidate()
+            playerItemKeepUpObservation?.invalidate()
             playerBufferingObservation = nil
             playerItemStatusObservation = nil
             playerItemKeepUpObservation = nil

--- a/GSPlayer/Classes/View/VideoPlayerView.swift
+++ b/GSPlayer/Classes/View/VideoPlayerView.swift
@@ -300,6 +300,8 @@ private extension VideoPlayerView {
     func observe(player: AVPlayer?) {
         
         guard let player = player else {
+            playerLayerReadyForDisplayObservation?.invalidate()
+            playerTimeControlStatusObservation?.invalidate()
             playerLayerReadyForDisplayObservation = nil
             playerTimeControlStatusObservation = nil
             return


### PR DESCRIPTION
### What this PR will do?
In this PR, invalidated all the `NSKeyValueObservers` before setting it to nil as a probable fix for iOS 12 specific crashes.