### PR TITLE
FLT-2443: Clean cache when device is on low storage and play videos on network

### DIFF
--- a/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
+++ b/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
@@ -56,7 +56,7 @@ extension AVPlayerItem {
     }
     
     convenience init(loader url: URL) {
-        if url.isFileURL || url.pathExtension == "m3u8" {
+        if url.isFileURL || url.pathExtension == "m3u8" || VideoPreloadManager.shared.isSpaceNotAvailable() {
             self.init(url: url)
             return
         }


### PR DESCRIPTION
## Summary
The app is crashing when scrolling through Videos continuously when the device storage is full.
- https://console.firebase.google.com/u/0/project/sharechat-firebase/crashlytics/app/ios:in.mohalla.sharechat/issues/87870f84326b0afe601c981ac7f9195e?time=last-ninety-days&sessionEventKey=1ca799884f2646c5a7602f313841a26c_1726361250991526889
- https://console.firebase.google.com/u/0/project/sharechat-firebase/crashlytics/app/ios:in.mohalla.sharechat/issues/ab9c0426ef863c56b159b3c37265ca34?time=last-ninety-days&sessionEventKey=4462bc8f791f4c4da921179941253375_1726363152377450510

## Scope of PR
- Sanity of the Videos on the feed and Video Player 

## Checklist:
- [X] I have self-reviewed my code
- [X] Added comments in hard-to-understand areas
- [X] My changes don't generate new warnings or errors from swiftlint
- [X] My changes support dark/light mode, RTL support(Urdu language)
- [X] My changes include error handling and support for no internet offline usage

## References
[FLT-2443](https://sharechat.atlassian.net/browse/FLT-2443)


[FLT-2443]: https://sharechat.atlassian.net/browse/FLT-2443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ